### PR TITLE
refactor to use enumerator

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     - redis:/data
 
   client:
-    image: ruby
+    image: ruby:2.6
     command: ./hack/client/entrypoint.sh
     volumes:
     - ./:/app
@@ -22,7 +22,7 @@ services:
       ZSPEC_BUILD_NUMBER: '1'
 
   worker:
-    image: ruby
+    image: ruby:2.6
     command: ./hack/worker/entrypoint.sh
     volumes:
     - ./:/app

--- a/lib/zspec.rb
+++ b/lib/zspec.rb
@@ -4,5 +4,6 @@ require "json"
 
 module ZSpec
   EXPIRE_SECONDS = 1800
+
   Dir[File.join(__dir__, "zspec", "*.rb")].each { |file| require file }
 end

--- a/lib/zspec/presenter.rb
+++ b/lib/zspec/presenter.rb
@@ -21,7 +21,8 @@ module ZSpec
     end
 
     def poll_results
-      @queue.process_done do |results, stdout|
+      @queue.done_queue.each do |results, stdout|
+        next if results.nil?
         present(::JSON.parse(results), stdout)
       end
       print_summary

--- a/lib/zspec/util.rb
+++ b/lib/zspec/util.rb
@@ -1,0 +1,23 @@
+module ZSpec
+  module Util
+    def timeout_key(message)
+      "#{message}:timeout"
+    end
+
+    def stdout_key(message)
+      "#{message}:stdout"
+    end
+
+    def results_key(message)
+      "#{message}:results"
+    end
+
+    def retry_key(message)
+      "#{message}:retries"
+    end
+
+    def dedupe_key(message)
+      "#{message}:dedupe"
+    end
+  end
+end

--- a/lib/zspec/worker.rb
+++ b/lib/zspec/worker.rb
@@ -9,7 +9,8 @@ module ZSpec
 
     def work
       require APPLICATION_FILE if File.exist? APPLICATION_FILE
-      @queue.proccess_pending do |spec|
+      @queue.pending_queue.each do |spec|
+        next if spec.nil?
         puts "running: #{spec}"
         fork do
           run_specs(spec, StringIO.new)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require "zspec"
 require "pry"
 
+include ZSpec::Util
+
 RSpec.configure do |c|
   c.before :each do
     @time = 1234

--- a/spec/zspec/formatter_spec.rb
+++ b/spec/zspec/formatter_spec.rb
@@ -4,7 +4,7 @@ describe ZSpec::Formatter do
   before :each do
     @message = "./spec/zspec/formatter_spec.rb"
     @queue.enqueue([@message1])
-    @queue.next_pending
+    @queue.pending_queue.next
 
     @formatter = ZSpec::Formatter.new(
       queue: @queue, tracker: @tracker, stdout: StringIO.new, message: @message1


### PR DESCRIPTION
This PR wraps the loop in an enumerator and returns nil rather than blocking while waiting for the next message. 

This way we can use #each in the worker/presenter and use #next in the tests without needing any special functions exposed just for testing.

This also makes the api more flexible for future changes, for example if we wanted to run files in groups, we can change the worker to use #each_slice and not need to make any changes to the underlying implementation... 